### PR TITLE
Add permissions error type

### DIFF
--- a/opseeproto/types/errors.go
+++ b/opseeproto/types/errors.go
@@ -2,6 +2,7 @@ package types
 
 import "fmt"
 
+// Equivalent to aws-sdk-go Error interface
 type OpseeError interface {
 	error
 
@@ -15,6 +16,7 @@ type OpseeError interface {
 	OrigErr() error
 }
 
+// Error error
 func (o Error) Code() string {
 	return o.ErrorCode
 }

--- a/opseeproto/types/permissions.go
+++ b/opseeproto/types/permissions.go
@@ -7,6 +7,9 @@ import (
 	"sync"
 )
 
+// the permission which corresponds to opsee administrator
+const OpseeAdmin = "opsee_admin"
+
 var PermissionsRegistry = NewPermsRegistry()
 
 func NewPermissionsBitmap() *PermissionsBitmap {
@@ -77,8 +80,8 @@ func (p *Permission) HighBits() []int {
 	return hb
 }
 
+// Returns a list of permissions we have
 func (p *Permission) Permissions() []string {
-	// TODO(dan) return registry errors
 	var perms []string
 	r, ok := PermissionsRegistry.Get(p.Name)
 	if !ok {
@@ -90,6 +93,37 @@ func (p *Permission) Permissions() []string {
 		}
 	}
 	return perms
+}
+
+// Checks permissions map for permission names, returns errors for those that do not exist
+func (p *Permission) HasPermissions(pnames ...string) map[string]bool {
+	hasPerms := make(map[string]bool)
+	retPerms := make(map[string]bool)
+	for _, p := range p.Permissions() {
+		hasPerms[p] = true
+	}
+
+	for _, name := range pnames {
+		if _, ok := hasPerms[name]; ok {
+			retPerms[name] = true
+		} else {
+			retPerms[name] = false
+		}
+	}
+	return retPerms
+}
+
+// Checks permissions map for permission names, returns errors for those that do not exist
+func (p *Permission) CheckPermissions(pnames ...string) map[string]error {
+	permErrs := make(map[string]error)
+	for name, has := range p.HasPermissions(pnames...) {
+		if !has {
+			permErrs[name] = NewPermissionsError(name)
+		} else {
+			permErrs[name] = nil
+		}
+	}
+	return permErrs
 }
 
 // Override MarshalJson to return a list of permissions
@@ -118,4 +152,8 @@ func (p *Permission) Validate() error {
 
 func (p *Permission) Value() (driver.Value, error) {
 	return int64(p.Perm), nil
+}
+
+func NewPermissionsError(pname string) *Error {
+	return NewError("PermissionsError", fmt.Sprintf("Not authorized: %s", pname))
 }


### PR DESCRIPTION
- Adds NewPermissionsError(permname string) helper function 
- Adds Permission.CheckPermissions(perm... string) which given a list of permission names, returns a map names -> opsee_type.Error generated by helper.
